### PR TITLE
Apply color formula to all sources

### DIFF
--- a/create-manifest.py
+++ b/create-manifest.py
@@ -163,7 +163,10 @@ def create_manifest(sources, tileset, license, account, product, date, notes,
         info['crs'] = crs
 
     if color:
-        info['color'] = color
+        info['color'] = {
+            # color formula assumed to apply to all sources
+            '.': color  
+        } 
 
     if ndv:
         info['ndv'] = ndv


### PR DESCRIPTION
Color formula needs to be a dict. For CLI simplicity, assume it applies to all sources. Source pattern matching with multiple color formulas must be done manually and is out of the scope of this CLI tool.

Sound good @vincentsarago ?