### PR TITLE
added pytests for manifest creation and validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+sudo: false
+cache:
+  directories:
+    - ~/.cache/pip
+
+python:
+  - "3.6"
+before_install:
+  - pip install -U pip
+install:
+  - "pip install -r requirements-dev.txt"
+script:
+  - python -m pytest manifest.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mapbox/pxm-manifest-specification.svg?branch=master)](https://travis-ci.org/mapbox/pxm-manifest-specification) 
+
 # pxm-manifest-specification
 
 ![pixelmonster](https://cloud.githubusercontent.com/assets/83384/4510319/28472d4a-4b29-11e4-8d02-0efc58ae4e7f.png)
@@ -87,7 +89,7 @@ which would generate the following output;
     "sources": [
         "s3://my-bucket/test.tif"
     ],
-    "version": "0.5.0"
+    "version": "0.5.1"
 }
 ```
 
@@ -109,12 +111,12 @@ aws s3 ls mybucket/mydata/ --recursive | grep -E '.tif$' | awk '{print "s3://myb
 
 PXM manifest uses [JSON Schemas](http://json-schema.org/) to validate manifest files.
 
-The file `schemas/pxm-manifest-0.5.0.json` is used to validate the PXM manifest file.
+The file `schemas/pxm-manifest-0.5.1.json` is used to validate the PXM manifest file.
 
 An example of using `jsonschema` from the command line is
 
 ```
-jsonschema -i render1.json schemas/pxm-manifest-0.5.0.json
+jsonschema -i render1.json schemas/pxm-manifest-0.5.1.json
 ```
 
 ### 3. Use manifest files to initiate a render

--- a/manifest.py
+++ b/manifest.py
@@ -29,7 +29,7 @@ import re
 
 import click
 
-version = "0.5.0"
+version = "0.5.1"
 
 
 # Custom click input types
@@ -234,3 +234,80 @@ def create_manifest(sources, tileset, license, account, product, date, notes,
 if __name__ == "__main__":
     create_manifest()
 
+# PyTest only below this line
+
+from click.testing import CliRunner
+from jsonschema import FormatChecker
+from jsonschema import validate
+import pytest
+
+import json
+import os
+
+
+err_msg = 'layers must follow the {account}.{id}'
+
+invalid_tileset_types = [
+    (
+        'a' * 33 + '.' + 'b' * 33,
+        err_msg
+    ),
+    (
+        '**!!',
+        err_msg
+    ),
+    (
+        'abcd-efgh',
+        err_msg
+    )
+]
+
+manifest_args = ['sources.txt',
+                 '-t', 'accountname.tileset',
+                 '--license', '"CC BY-SA"',
+                 '--account', 'accountname',
+                 '--product', 'productname',
+                 '--date', '2018'
+                 ]
+
+
+@pytest.fixture
+def runner():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('sources.txt', 'w') as f:
+            f.write('s3://my-bucket/test.tif')
+        yield runner
+
+
+def test_create_manifest(runner):
+    """Tests the create manifest function checking for exceptions."""
+    result = runner.invoke(create_manifest, manifest_args)
+    assert result.exit_code == 0
+    doc = json.loads(result.output)
+    assert len(doc['sources']) == 1
+
+
+@pytest.mark.parametrize('tileset,expected', invalid_tileset_types)
+def test_invalid_tileset(runner, tileset, expected):
+    """Tests the create manifest function checking for exceptions."""
+    args = manifest_args.copy()
+    args[2] = tileset
+    result = runner.invoke(create_manifest, args)
+    assert expected in result.output
+    assert result.exit_code == 1
+
+
+def test_json_schema(runner):
+    """Tests that the json schema is in sync with this code."""
+    schema_dir = os.path.dirname(os.path.realpath(__file__))
+    fname = os.path.join(schema_dir, f'schemas/pxm-manifest-{version}.json')
+    with open(fname) as f:
+        schema = json.load(f)
+
+        result = runner.invoke(create_manifest, manifest_args)
+        doc = json.loads(result.output)
+
+        assert result.exit_code == 0
+        # if an exception is raised by validate then the test fails
+        validate(doc, schema, format_checker=FormatChecker())

--- a/pxm-manifest-spec.md
+++ b/pxm-manifest-spec.md
@@ -3,7 +3,7 @@
 * Status: DRAFT, not for production use
 * Authors: Mapbox Satellite team
 * Date: April 13, 2018
-* Version: 0.5.0
+* Version: 0.5.1
 
 ## 1. Summary
 
@@ -191,7 +191,7 @@ The following is a minimal PXM manifest in JSON format
         "product": "november_aerial_photos",
         "notes": "Aerial photos from November 2017, Northern California",
       },
-      "version": "0.5.0"
+      "version": "0.5.1"
     }
 ```
 
@@ -223,6 +223,6 @@ The following is a complete PXM manifest in JSON format
         "notes": "Aerial photos from November 2017, Northern California",
         "crs": "EPSG:26910"
       },
-      "version": "0.5.0"
+      "version": "0.5.1"
     }
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 click==7.0
 jsonschema==2.6.0
 strict-rfc3339==0.7
+pytest==4.0.1

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,15 +1,15 @@
 PXM JSON Schemas
 ================
 
-pxm-manifest-0.5.0.json
+pxm-manifest-0.5.1.json
 -----------------------
 
-This schema can be used to validate a PXM manifest file (version 0.5.0).
+This schema can be used to validate a PXM manifest file (version 0.5.1).
 
 The example below uses the Python jsonschema package.
 
 ```
-$ python -m jsonschema -i manifest.json pxm-manifest-0.5.0.json
+$ python -m jsonschema -i manifest.json pxm-manifest-0.5.1.json
 ```
 
 pxm-source-gdal-1.0.0.json

--- a/schemas/pxm-manifest-0.5.1.json
+++ b/schemas/pxm-manifest-0.5.1.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "https://raw.githubusercontent.com/mapbox/pxm-manifest-specification/schemas/pxm-manifest-0.5.1.json",
+	"name": "PXM Manifest",
+	"type": "object",
+	"properties": {
+		"sources": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"pattern": "^s3://.+/[a-zA-Z0-9_]+\\..+$"
+			}
+		},
+		"info": {
+			"type": "object",
+			"properties": {
+				"tilesets": {
+					"type": "array",
+					"description": "",
+					"items": {
+						"type": "string",
+						"pattern": "^[a-z0-9-]{1,32}\\.[a-zA-Z0-9-_]{1,32}$"
+					}
+				},
+				"license": {
+					"type": "string",
+					"description": ""
+				},
+				"notes": {
+					"type": "string",
+					"description": ""
+				},
+				"account": {
+					"type": "string",
+					"description": "",
+					"pattern": "^[a-z0-9-_]{1,32}$"
+				},
+				"product": {
+					"type": "string",
+					"description": ""
+				},
+				"date": {
+					"type": "string",
+					"description": "",
+					"oneOf": [{
+							"format": "date"
+						},
+						{
+							"format": "string",
+							"pattern": "^[0-9]{4}$"
+						}
+					]
+				},
+				"bidx": {
+					"type": "array",
+					"description": "",
+					"minItems": 3,
+					"maxItems": 4,
+					"items": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"uniqueItems": true
+				},
+				"crs": {
+					"type": "string",
+					"description": "",
+					"pattern": "^EPSG:[0-9]+$"
+				},
+				"color": {
+					"type": "object",
+					"description": "",
+					"patternProperties": {
+						".+": {
+							"type": "string",
+							"pattern": "(saturation [0-9]+(.[0-9]+)?)?(sigmoidal [rgb]{1,3} [0-9]+ [0-9]+(.[0-9]+)?)?(gamma [rgb]{1,3} [0-9]+(.[0-9]+)?)?"
+						}
+					}
+				},
+				"ndv": {
+					"type": "array",
+					"description": "",
+					"minItems": 3,
+					"maxItems": 3,
+					"items": {
+						"type": "integer"
+					}
+				}
+			},
+			"required": [
+				"tilesets",
+				"license",
+				"notes",
+				"account",
+				"product",
+				"date"
+			]
+		},
+		"version": {
+			"type": "string",
+			"description": "^(\\d+\\.){2}(\\d+)$"
+		}
+	},
+	"required": [
+		"info",
+		"sources",
+		"version"
+	]
+}


### PR DESCRIPTION
Added pytest for manifest creation and schema testing. This required a modification of the pxm-manifest-0.5.0 schema to change the format specifier for dates. This didn't change the behaviour of the command line tools, just when testing in code and enforcing the format checker.  Before we merge this PR we should bump to 0.5.1.