### PR TITLE
Fix NDV and BIDX, update docs

### DIFF
--- a/pxm-manifest-spec.md
+++ b/pxm-manifest-spec.md
@@ -146,24 +146,24 @@ If there are multiple color formula's that need to be applied, use a string uniq
 
 #### 3.2.9. ndv
 
-Optional. Array of size 3 of integers defining the the `nodata` value of the red, green and blue bands respectively.  Often, this value will be either `[255, 255, 255]` or `[0, 0, 0]`. Do not specify `ndv` if your source data already contains the correct nodata value in the raster’s metadata.
+Optional. A string representation of a list containing per-band nodata values.  Often, this value will be either `[255, 255, 255]` or `[0, 0, 0]`. Do not specify `ndv` if your source data already contains the correct nodata value in the raster’s metadata.
 
 For example,
 
-    "ndv": [0, 0, 0]
+    "ndv": "[0, 0, 0]"
     or
-    "ndv": [255, 255, 255]
+    "ndv": "[255, 255, 255]"
 
 #### 3.2.10. bidx
 
 Optional. The band indexes used to form an RGB image from source data. The source data may have superflous bands, different band ordering, or some other band configuration that prevents from pxm from using it directly.
 
-The optional `bidx` describes which bands to use. The value should be a array of integers representing the band indexes for red, green and blue respectively. All other bands will be dropped (useful for dropping the near-infrared band for example)
+The optional `bidx` describes which bands to use. The value must be a string with 3 or 4 integers that are comma-separated, representing the band indexes for Red, Green ,Blue (,Alpha)'. All other bands will be dropped (useful for dropping the near-infrared band for example)
 
 The value is passed directly to the [rio stack](https://github.com/mapbox/rasterio/blob/master/docs/cli.rst#stack) `--bidx` option.
 
 
-    "bidx": [1, 2, 3]
+    "bidx": "1, 2, 3"
 
 ## 4. version
 
@@ -214,8 +214,8 @@ The following is a complete PXM manifest in JSON format
             ".": "sigmoidal RGB 4 0.5",
             "7RLL675": "sigmoidal RGB 3 0.4 gamma B 1.1 saturation 1.25"
         },
-        "bidx": [1, 2, 3],
-        "ndv": [255, 255, 255],
+        "bidx": "1, 2, 3",
+        "ndv": "[255, 255, 255]",
         "date": "2018-02-20",
         "license": "cc by-sa 4.0",
         "account": "customer1",

--- a/schemas/pxm-manifest-0.5.1.json
+++ b/schemas/pxm-manifest-0.5.1.json
@@ -52,15 +52,9 @@
 					]
 				},
 				"bidx": {
-					"type": "array",
+					"type": "string",
 					"description": "",
-					"minItems": 3,
-					"maxItems": 4,
-					"items": {
-						"type": "integer",
-						"minimum": 1
-					},
-					"uniqueItems": true
+					"pattern": "[0-9]+,\\s?[0-9]+,\\s?[0-9]+"
 				},
 				"crs": {
 					"type": "string",
@@ -78,14 +72,11 @@
 					}
 				},
 				"ndv": {
-					"type": "array",
+					"type": "string",
 					"description": "",
-					"minItems": 3,
-					"maxItems": 3,
-					"items": {
-						"type": "integer"
+					"pattern": "\\[[0-9]+,\\s?[0-9]+,\\s?[0-9]+\\]"
+
 					}
-				}
 			},
 			"required": [
 				"tilesets",


### PR DESCRIPTION
### Error that prompted these changes:
#### 1. Running `--ndv "[0, 0, 0]"`
```
❯ python manifest.py source_list.txt --account customer1 --date 2019 --license cc by-sa 4.0 --notes Aerial photos from November 2019, Northern California --product november_aerial_photos --ndv "[0, 0, 0]" --bidx 1,2,3 --color sigmoidal rgb 3 0.5 -t customer1.aerials--output manifest.json
Traceback (most recent call last):
  File "manifest.py", line 235, in <module>
    create_manifest()
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 716, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 641, in make_context
    self.parse_args(ctx, args)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 940, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1469, in handle_parse_result
    value = self.full_process_value(ctx, value)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1790, in full_process_value
    return Parameter.full_process_value(self, ctx, value)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1438, in full_process_value
    value = self.process_value(ctx, value)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1428, in process_value
    return self.type_cast_value(ctx, value)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1417, in type_cast_value
    return _convert(value, (self.nargs != 1) + bool(self.multiple))
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/core.py", line 1415, in _convert
    return self.type(value, self, ctx)
  File "/Users/virginiang/venv368/lib/python3.6/site-packages/click/types.py", line 39, in __call__
    return self.convert(value, param, ctx)
  File "manifest.py", line 111, in convert
    ndv = [int(x) for x in value.split(',')]
  File "manifest.py", line 111, in <listcomp>
    ndv = [int(x) for x in value.split(',')]
ValueError: invalid literal for int() with base 10: '[0'
```


This PR fixes the format of NDV and BIDX:
```
❯ python manifest.py source_list.txt --account customer1 --date 2019 --license "cc by-sa 4.0" --notes "Aerial photos from November 2019, Northern California" --product november_aerial_photos --ndv "[0, 0, 0]" --bidx 1,2,3 --color "sigmoidal rgb 3 0.5" -t customer1.aerials --output manifest.json
❯ cat manifest.json                                                                         ✭
{
    "info": {
        "account": "customer1",
        "bidx": "1,2,3",
        "color": {
            ".": "sigmoidal rgb 3 0.5"
        },
        "date": "2019",
        "license": "cc by-sa 4.0",
        "ndv": "[0, 0, 0]",
        "notes": "Aerial photos from November 2019, Northern California",
        "product": "november_aerial_photos",
        "tilesets": [
            "customer1.aerials"
        ]
    },
    "sources": [
        "s3://my-bucket/20190101/17RLL630825.tif",
        "s3://my-bucket/20190101/17RLL630826.tif",
        "s3://my-bucket/20190101/17RLL630827.tif"
    ],
    "version": "0.5.1"
}
```



cc @pratikyadav @jacquestardie 